### PR TITLE
Update peerDependencies to support Grunt 1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,39 +1,41 @@
 {
-    "name":        "grunt-newer-explicit",
-    "homepage":    "http://github.com/rse/grunt-newer-explicit",
+    "name": "grunt-newer-explicit",
+    "homepage": "http://github.com/rse/grunt-newer-explicit",
     "description": "Grunt Task for running tasks if source files are newer only",
-    "version":     "0.9.4",
-    "license":     "MIT",
+    "version": "0.9.4",
+    "license": "MIT",
     "author": {
-        "name":    "Ralf S. Engelschall",
-        "email":   "rse@engelschall.com",
-        "url":     "http://engelschall.com"
+        "name": "Ralf S. Engelschall",
+        "email": "rse@engelschall.com",
+        "url": "http://engelschall.com"
     },
     "keywords": [
         "gruntplugin",
-        "newer", "time", "mtime"
+        "newer",
+        "time",
+        "mtime"
     ],
     "repository": {
         "type": "git",
-        "url":  "git://github.com/rse/grunt-newer-explicit.git"
+        "url": "git://github.com/rse/grunt-newer-explicit.git"
     },
     "bugs": {
-        "url":  "http://github.com/rse/grunt-newer-explicit/issues"
+        "url": "http://github.com/rse/grunt-newer-explicit/issues"
     },
     "main": "Gruntfile.js",
     "devDependencies": {
-        "grunt":                "~0.4.5",
-        "grunt-cli":            "~0.1.13",
+        "grunt": "~0.4.5",
+        "grunt-cli": "~0.1.13",
         "grunt-contrib-jshint": "~0.10.0",
-        "grunt-contrib-clean":  "~0.6.0"
+        "grunt-contrib-clean": "~0.6.0"
     },
     "peerDependencies": {
-        "grunt":                "~0.4.5"
+        "grunt": ">=0.4.0"
     },
     "dependencies": {
-        "chalk":                "~0.5.1"
+        "chalk": "~0.5.1"
     },
     "engines": {
-        "node":                 ">=0.10.0"
+        "node": ">=0.10.0"
     }
 }


### PR DESCRIPTION
Update peerDependencies to support Grunt 1.0

Hello,

This is an automated issue request to update the `peerDependencies` for your Grunt plugin.
We ask you to merge this and **publish a new release on npm** to get your plugin working in Grunt 1.0!

Read more here: http://gruntjs.com/blog/2016-02-11-grunt-1.0.0-rc1-released#peer-dependencies
Also on Twitter: https://twitter.com/gruntjs/status/700819604155707392

If you have any questions or you no longer have time to maintain this plugin, then please let us know in this thread.

Thanks for creating and working on this plugin!

(P.S. Close this PR if it is a mistake, sorry)
